### PR TITLE
Make installable from dev-repo

### DIFF
--- a/matplotlib.opam
+++ b/matplotlib.opam
@@ -8,7 +8,7 @@ authors:      [ "Laurent Mazare" ]
 
 version: "dev"
 
-build: [["dune" "build" "-j" jobs "@install"]]
+build: [["dune" "build" "-p" name "-j" jobs "@install"]]
 
 install: []
 remove:  []


### PR DESCRIPTION
Before this PR when I tried to install with `opam pin matplotlib --dev-repo` the package could not be found with `ocamlfind`. Opam docs [suggest](https://opam.ocaml.org/doc/Packaging.html) using `build: ["dune" "build" "-p" name "-j" jobs]` which seems to fix the problem.